### PR TITLE
[WIP] Add Dockerfile to server applications

### DIFF
--- a/LoadBalancerProject-DONT-IMPORT-INTO-UNITY/Dockerfile
+++ b/LoadBalancerProject-DONT-IMPORT-INTO-UNITY/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS builder
+WORKDIR /lrm
+COPY . .
+RUN [\
+    "dotnet", "publish", \
+    "--output", "/build/", \
+    "--configuration", "Release",\
+    "--no-self-contained", \
+    "." ]
+
+FROM mcr.microsoft.com/dotnet/runtime:5.0-alpine
+WORKDIR /lrm-lb
+COPY --from=builder /build/ .
+ENV LRM_LB_CONFIG_PATH="/config/config-load-balancer.json"
+CMD [ "./LRM_LoadBalancer" ]
+ENTRYPOINT [ "./LRM_LoadBalancer" ]

--- a/LoadBalancerProject-DONT-IMPORT-INTO-UNITY/LRM_LoadBalancer/Program.cs
+++ b/LoadBalancerProject-DONT-IMPORT-INTO-UNITY/LRM_LoadBalancer/Program.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -18,7 +18,7 @@ namespace LightReflectiveMirror.LoadBalancing
 
         private int _pingDelay = 10000;
         const string API_PATH = "/api/stats";
-        const string CONFIG_PATH = "config.json";
+        readonly string CONFIG_PATH = System.Environment.GetEnvironmentVariable("LRM_LB_CONFIG_PATH") ?? "config.json";
 
         public static Config conf;
         public static Program instance;

--- a/ServerProject-DONT-IMPORT-INTO-UNITY/Dockerfile
+++ b/ServerProject-DONT-IMPORT-INTO-UNITY/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS builder
+WORKDIR /lrm
+COPY . .
+RUN [\
+    "dotnet", "publish", \
+    "--output", "/build/", \
+    "--configuration", "Release",\
+    "--no-self-contained", \
+    "." ]
+
+FROM mcr.microsoft.com/dotnet/runtime:5.0-alpine
+WORKDIR /lrm
+COPY --from=builder /build/ .
+COPY ./MultiCompiled.dll .
+ENV LRM_CONFIG_PATH="/config/config.json"
+CMD [ "./LRM" ]
+ENTRYPOINT [ "./LRM" ]

--- a/ServerProject-DONT-IMPORT-INTO-UNITY/LRM/Program.cs
+++ b/ServerProject-DONT-IMPORT-INTO-UNITY/LRM/Program.cs
@@ -37,7 +37,7 @@ namespace LightReflectiveMirror
 
         private UdpClient _punchServer;
 
-        private const string CONFIG_PATH = "config.json";
+        private readonly string CONFIG_PATH = System.Environment.GetEnvironmentVariable("LRM_CONFIG_PATH") ?? "config.json";
 
         public static void Main(string[] args) => new Program().MainAsync().GetAwaiter().GetResult();
 
@@ -67,7 +67,7 @@ namespace LightReflectiveMirror
                 WriteLogMessage("Loading Assembly... ", ConsoleColor.White, true);
                 try
                 { 
-                    var asm = Assembly.LoadFile(Directory.GetCurrentDirectory() + @"\" + conf.TransportDLL);
+                    var asm = Assembly.LoadFile(Path.GetFullPath(conf.TransportDLL));
                     WriteLogMessage($"OK", ConsoleColor.Green);
 
                     WriteLogMessage("\nLoading Transport Class... ", ConsoleColor.White, true);


### PR DESCRIPTION
This PR adds two Dockerfiles that build and run the load balancer and the relay using Docker. This makes the process of deploying this application so much easier.

## Code Changes

I've had to make two minor changes to the code, I don't think they're breaking changes though:

The first one lets you specify the main config file location via an environment variable, this separates binaries from configuration and facilitates the use of docker volumes to store the configuration files. This was added on both applications named `LRM_CONFIG_PATH` and `LRM_LB_CONFIG_PATH`

The other change was to fix the backslash used to build the `TransportDLL` file path, Linux doesn't handle backslashes well. The correct way of joining paths is using `Path.Combine`, I've used `Path.GetFullPath` in the fix since users can refer to the DLL using both relative and absolute notations.

## How to build and run the images

I don't know how you guys are building the `MultiCompiled.dll`, so I just throwed it in the project and the docker file is copying it to the final image, the build process can be improved to build this DLL as well.

### Building the images
- `docker build -t lrm/relay ServerProject-DONT-IMPORT-INTO-UNITY`
- `docker build -t lrm/load-balancer LoadBalancerProject-DONT-IMPORT-INTO-UNITY`

### Running
- `docker run -it --rm -p 8000:8080 -v E:\Repos\Light-Reflective-Mirror\config:/config --name lrm-sample lrm/relay`
- `docker run -it --rm -p 8000:8080 -v E:\Repos\Light-Reflective-Mirror\config:/config --name lrm-lb-sample lrm/load-balancer`
_Change the config folder to something that makes sense in your environment_

## Going forward

Let me know what you guys think about this PR. This can be improved to auto-deploy the images to Docker Hub using GitHub actions or some CI/CD solution.
