### PR TITLE
Use delegate to replace MethodInfo.Invoke, And remove dependency with Json.net 

### DIFF
--- a/ServerProject-DONT-IMPORT-INTO-UNITY/LRM/Program/Program.cs
+++ b/ServerProject-DONT-IMPORT-INTO-UNITY/LRM/Program/Program.cs
@@ -85,8 +85,8 @@ namespace LightReflectiveMirror
             {
                 try
                 {
-                    if (_updateMethod != null) _updateMethod.Invoke(transport, null);
-                    if (_lateUpdateMethod != null) _lateUpdateMethod.Invoke(transport, null);
+                    _updateMethod?.Invoke();
+                    _lateUpdateMethod?.Invoke();
                 }
                 catch (Exception e)
                 {

--- a/ServerProject-DONT-IMPORT-INTO-UNITY/LRM/Program/ProgramConfigurator.cs
+++ b/ServerProject-DONT-IMPORT-INTO-UNITY/LRM/Program/ProgramConfigurator.cs
@@ -23,11 +23,9 @@ namespace LightReflectiveMirror
 
             WriteLogMessage("\nInvoking Transport Methods...");
 
-            if (_awakeMethod != null)
-                _awakeMethod.Invoke(transport, null);
+            _awakeMethod?.Invoke();
 
-            if (_startMethod != null)
-                _startMethod.Invoke(transport, null);
+            _startMethod?.Invoke();
 
             WriteLogMessage("\nStarting Transport... ", ConsoleColor.White, true);
 
@@ -141,10 +139,20 @@ namespace LightReflectiveMirror
 
         void CheckMethods(Type type)
         {
-            _awakeMethod = type.GetMethod("Awake", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-            _startMethod = type.GetMethod("Start", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-            _updateMethod = type.GetMethod("Update", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-            _lateUpdateMethod = type.GetMethod("LateUpdate", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            _awakeMethod = CreateTransportDelegate(type.GetMethod("Awake", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
+            _startMethod = CreateTransportDelegate(type.GetMethod("Start", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
+            _updateMethod = CreateTransportDelegate(type.GetMethod("Update", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
+            _lateUpdateMethod = CreateTransportDelegate(type.GetMethod("LateUpdate", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
+        }
+        delegate void TransportMethodDelegate();
+        TransportMethodDelegate CreateTransportDelegate(MethodInfo mi)
+        {
+            if (mi == null)
+            {
+                return null;
+            }
+            var openDelegate = Delegate.CreateDelegate(typeof(TransportMethodDelegate), transport, mi, true);
+            return openDelegate as TransportMethodDelegate;
         }
     }
 }

--- a/ServerProject-DONT-IMPORT-INTO-UNITY/LRM/Program/ProgramVariables.cs
+++ b/ServerProject-DONT-IMPORT-INTO-UNITY/LRM/Program/ProgramVariables.cs
@@ -15,10 +15,10 @@ namespace LightReflectiveMirror
         public static Config conf;
         
         private RelayHandler _relay;
-        private MethodInfo _awakeMethod;
-        private MethodInfo _startMethod;
-        private MethodInfo _updateMethod;
-        private MethodInfo _lateUpdateMethod;
+        private TransportMethodDelegate _awakeMethod;
+        private TransportMethodDelegate _startMethod;
+        private TransportMethodDelegate _updateMethod;
+        private TransportMethodDelegate _lateUpdateMethod;
 
         private DateTime _startupTime;
         public static string publicIP;

--- a/UnityProject/Assets/Mirror/Runtime/Transport/LRM/LRMTransport/LRMTransportRequests.cs
+++ b/UnityProject/Assets/Mirror/Runtime/Transport/LRM/LRMTransport/LRMTransportRequests.cs
@@ -1,5 +1,4 @@
 ﻿using Mirror;
-using Newtonsoft.Json;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -9,6 +8,7 @@ namespace LightReflectiveMirror
 {
     public partial class LightReflectiveMirrorTransport : Transport
     {
+        public static System.Func<string, System.Type, object> OnDeserializeJson;
 
         public void RequestServerList(LRMRegions searchRegion = LRMRegions.Any)
         {
@@ -43,7 +43,7 @@ namespace LightReflectiveMirror
                         break;
 
                     case UnityWebRequest.Result.Success:
-                        var parsedAddress = JsonConvert.DeserializeObject<RelayAddress>(result);
+                        var parsedAddress = (RelayAddress)OnDeserializeJson.Invoke(result, typeof(RelayAddress));
                         Connect(parsedAddress.Address, parsedAddress.Port);
                         endpointServerPort = parsedAddress.EndpointPort;
                         break;
@@ -56,7 +56,7 @@ namespace LightReflectiveMirror
                 else
                 {
                     // join here
-                    var parsedAddress = JsonConvert.DeserializeObject<RelayAddress>(result);
+                    var parsedAddress = (RelayAddress)OnDeserializeJson.Invoke(result,typeof(RelayAddress));
                     Connect(parsedAddress.Address, parsedAddress.Port);
                     endpointServerPort = parsedAddress.EndpointPort;
                 }
@@ -148,7 +148,7 @@ namespace LightReflectiveMirror
 
                         case UnityWebRequest.Result.Success:
                             relayServerList?.Clear();
-                            relayServerList = JsonConvert.DeserializeObject<List<Room>>(result.Decompress());
+                            relayServerList = (List<Room>)OnDeserializeJson.Invoke(result.Decompress(), typeof(List<Room>));
                             serverListUpdated?.Invoke();
                             break;
                     }
@@ -160,7 +160,7 @@ namespace LightReflectiveMirror
                     else
                     {
                         relayServerList?.Clear();
-                        relayServerList = JsonConvert.DeserializeObject<List<Room>>(result.Decompress());
+                        relayServerList = (List<Room>)OnDeserializeJson.Invoke(result.Decompress(), typeof(List<Room>));
                         serverListUpdated?.Invoke();
                     }
 #endif
@@ -201,7 +201,7 @@ namespace LightReflectiveMirror
 
                     case UnityWebRequest.Result.Success:
                         relayServerList?.Clear();
-                        relayServerList = JsonConvert.DeserializeObject<List<Room>>(result);
+                        relayServerList = (List<Room>)OnDeserializeJson.Invoke(result, typeof(List<Room>));
                         serverListUpdated?.Invoke();
                         _serverListUpdated = true;
                         break;
@@ -214,7 +214,7 @@ namespace LightReflectiveMirror
                 else
                 {
                     relayServerList?.Clear();
-                    relayServerList = JsonConvert.DeserializeObject<List<Room>>(result);
+                    relayServerList = (List<Room>)OnDeserializeJson.Invoke(result, typeof(List<Room>));
                     serverListUpdated?.Invoke();
                     _serverListUpdated = true;
                 }

--- a/UnityProject/Assets/Mirror/Runtime/Transport/LRM/LRMTransport/LightReflectiveMirrorTransport.cs
+++ b/UnityProject/Assets/Mirror/Runtime/Transport/LRM/LRMTransport/LightReflectiveMirrorTransport.cs
@@ -41,7 +41,24 @@ namespace LightReflectiveMirror
             if (connectOnAwake)
                 ConnectToRelay();
 
+            RegisterDefaultJsonDeserializer();
+
             InvokeRepeating(nameof(SendHeartbeat), heartBeatInterval, heartBeatInterval);
+        }
+
+        void RegisterDefaultJsonDeserializer()
+        {
+            LightReflectiveMirror.LightReflectiveMirrorTransport.OnDeserializeJson = (result, type) =>
+            {
+                // Since JsonUtility didn't support json with array as root, make a wrapper.
+                if (type == typeof(List<Room>))
+                {
+                    result = "{ \"rooms\":" + result + "}";
+                    var r = JsonUtility.FromJson<RoomWrapper>(result);
+                    return r.rooms;
+                }
+                return JsonUtility.FromJson(result, type);
+            };
         }
 
         private void SetupCallbacks()
@@ -426,6 +443,13 @@ namespace LightReflectiveMirror
 
             return null;
         }
+    }
+
+
+    [Serializable]
+    public struct RoomWrapper
+    {
+        public List<Room> rooms;
     }
 
     [Serializable]


### PR DESCRIPTION
There are 2 changes on this pull request.

## Use delegate to replace MethodInfo.Invoke

On sever I notice that have MethodInfo.Invoke on every heartbeat loops.
I create a delegate to cache MethodInfo.
With delegate instead of MethodInfo.Invoke, we will have about 100 times better performance than original one while call a method.

## Remove dependency with Json.net 

As the #17 said, I think it is better to have a method to use users already exists Json library in project to avoid make the binary bigger.

In most of the case, Unity's JsonUtility is enough for the deserialize, so I remove Json.net and use JsonUtility as the default deserializer.
The only problem is JsonUtility didn't support deserialize json object which is Array object.
Currently, I do a small hack in LightReflectiveMirrorTransport.cs to make the JsonUtility work like this, in this part maybe we will have a better solution later.

```csharp
// RegisterDefaultJsonDeserializer() is called in LightReflectiveMirrorTransport.Awake()
void RegisterDefaultJsonDeserializer()
        {
            LightReflectiveMirror.LightReflectiveMirrorTransport.OnDeserializeJson = (result, type) =>
            {
                // Since JsonUtility didn't support json with array as root, make a wrapper.
                if (type == typeof(List<Room>))
                {
                    result = "{ \"rooms\":" + result + "}";
                    var r = JsonUtility.FromJson<RoomWrapper>(result);
                    return r.rooms;
                }
                return JsonUtility.FromJson(result, type);
            };
        }
```

Anyway, user can override the Json deserialize, we can do something like this:
```csharp
// sample use LitJson
LightReflectiveMirror.LightReflectiveMirrorTransport.OnDeserializeJson = (result, type) =>
{
    return LitJson.JsonMapper.ToObject(result, type);
};

//sample use Json.net
LightReflectiveMirror.LightReflectiveMirrorTransport.OnDeserializeJson = (result, type) =>
{
    return JsonConvert.DeserializeObject(result, type);
};
```
